### PR TITLE
fix: Improve macOS dotfiles setup, reliability, and performance

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -1,9 +1,16 @@
-eval "$(starship init zsh)"
+# --- Homebrew Shellenv ---
+if [[ $(uname -m) == 'arm64' ]]; then
+  eval "$(/opt/homebrew/bin/brew shellenv 2>/dev/null)"
+else
+  eval "$(/usr/local/bin/brew shellenv 2>/dev/null)"
+fi
+
 # --- iTerm2 Shell Integration ---
 # This must be sourced for features like marks, badges, and directory tracking.
 if [ -f "${HOME}/.iterm2_shell_integration.zsh" ]; then
   source "${HOME}/.iterm2_shell_integration.zsh"
 fi
+
 # =================================================================
 # Zsh Completion System Initialization
 # =================================================================
@@ -26,9 +33,9 @@ if [ -f "${HOME}/.zgenom/zgenom.zsh" ]; then
 
       # Essential plugins for a clean, fast setup with zoxide
       zgenom load zsh-users/zsh-completions
-      zgenom load zsh-users/zsh-syntax-highlighting
-      zgenom load zsh-users/zsh-autosuggestions
       zgenom load Aloxaf/fzf-tab
+      zgenom load zsh-users/zsh-autosuggestions
+      zgenom load zsh-users/zsh-syntax-highlighting
 
       zgenom save
   fi
@@ -64,8 +71,9 @@ fi
 # Better directory listing
 if command -v eza &> /dev/null; then
     alias ls="eza --icons"
-    alias ll="eza -l --icons --git"
-    alias la="eza -la --icons --git"
+    alias ll="eza -la --icons --git"
+    alias la="eza -a --icons --git"
+    alias lt="eza -T --icons"
     alias tree="eza --tree --icons"
 fi
 
@@ -97,11 +105,13 @@ fi
 # Miscellaneous Settings
 # =================================================================
 alias v="nvim"
-# Eza settings and aliases
-alias ls="eza --icons"
-alias ll="eza -la --icons --git"
-alias la="eza -a --icons --git"
-alias lt="eza -T --icons"
 
 export EDITOR="nvim"
 export VISUAL="nvim"
+
+# =================================================================
+# Prompt Initialization
+# =================================================================
+if command -v starship &> /dev/null; then
+    eval "$(starship init zsh)"
+fi

--- a/setup.sh
+++ b/setup.sh
@@ -2,7 +2,7 @@
 # setup.sh - The One-Click Installer
 # Installs Xcode tools, Homebrew, packages, updates submodules, and links dotfiles.
 
-set -e
+set -euo pipefail
 
 # --- Helper Functions ---
 info() { printf "\033[1;34m%s\033[0m\n" "$1"; }
@@ -27,7 +27,7 @@ fi
 # 1. Install Homebrew (if missing)
 if ! command -v brew &> /dev/null; then
   info "🍺 Installing Homebrew..."
-  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
   
   # Add brew to PATH for this session (Apple Silicon vs Intel logic)
   if [[ $(uname -m) == 'arm64' ]]; then
@@ -67,7 +67,7 @@ if [ ! -d "$HOME/.zgenom" ]; then
 fi
 
 info "🔌 Updating Zsh plugins (zgenom)..."
-zsh -i -c "zgenom selfupdate && zgenom update"
+zsh -c "source $HOME/.zshrc && zgenom selfupdate && zgenom update"
 
 # 6. iTerm2 Profile
 if [ -d "/Applications/iTerm.app" ]; then

--- a/symlink.sh
+++ b/symlink.sh
@@ -2,7 +2,7 @@
 # Universal Dotfile Linker
 # Automatically symlinks all dotfiles/folders in this repo to $HOME.
 
-set -e
+set -euo pipefail
 
 # --- Helper Functions ---
 info() { printf "\033[1;34m%s\033[0m\n" "$1"; }
@@ -20,7 +20,7 @@ fi
 
 # --- Configuration ---
 # Files/Folders to completely ignore
-IGNORES=("." ".." ".git" ".gitmodules" ".gitignore" ".DS_Store" ".macos" "README.md" "LICENSE" "symlink.sh" "deploy.sh" "Brewfile" "GEMINI.md" ".github" "astronvim_template" "nvim-custom" ".zshrc")
+IGNORES=("." ".." ".git" ".githooks" ".gitmodules" ".gitignore" ".DS_Store" ".macos" "README.md" "LICENSE" "symlink.sh" "deploy.sh" "Brewfile" "GEMINI.md" ".github" "astronvim_template" "nvim-custom" ".zshrc")
 
 # Explicit mapping for things that don't map 1:1 (Source -> Target relative to HOME)
 # Format: "source_in_repo:target_path_from_home"


### PR DESCRIPTION
This PR addresses several issues and applies performance improvements to the macOS dotfiles environment, making it more robust and reliable.

### Key Changes:
1.  **Strict Error Handling:** Applied `set -euo pipefail` to both `setup.sh` and `symlink.sh` to prevent silent failures and catch uninitialized variables or command errors immediately.
2.  **Automated Installations:** The Homebrew installer in `setup.sh` now uses `NONINTERACTIVE=1` to guarantee it runs without prompting the user. The `zgenom` update command was updated to run non-interactively, sourcing `.zshrc` explicitly.
3.  **Path Resolution on Fresh Mac:** Added logic to `eval` the Homebrew `shellenv` (handling both Apple Silicon `arm64` and Intel) at the very top of `.zshrc`. This is critical for fresh macOS installations so that subsequent commands (like `eza`, `starship`, `bat`) are found in the PATH.
4.  **Zsh Plugin Order:** Corrected the load order of `zgenom` plugins. `zsh-syntax-highlighting` must be loaded last to function properly; otherwise, it interferes with completions and autosuggestions.
5.  **Prompt Initialization:** Moved `eval "$(starship init zsh)"` to the bottom of `.zshrc` and guarded it with a `command -v` check to ensure the prompt is rendered properly after all other configurations and plugins are loaded.
6.  **Alias Cleanup:** Removed redundant `eza` aliases in `.zshrc` and consolidated them inside the safe `command -v eza` block.
7.  **Symlink Exclusions:** Added `.githooks` to the ignore list in `symlink.sh` to prevent repo-specific hooks from cluttering the user's home directory.

---
*PR created automatically by Jules for task [12478853945879876897](https://jules.google.com/task/12478853945879876897) started by @russellkim98*