### PR TITLE
🧹 Refactor System Preferences/Settings App Quitting in .macos

### DIFF
--- a/.macos
+++ b/.macos
@@ -3,7 +3,8 @@
 # Concise and Less Intrusive macOS Defaults Script
 
 # Close any open System Preferences panes so changes can take effect immediately
-osascript -e 'tell application "System Preferences" to quit'
+osascript -e 'if application "System Preferences" is running then tell application "System Preferences" to quit'
+osascript -e 'if application "System Settings" is running then tell application "System Settings" to quit'
 
 # --- Essential Quality-of-Life UI Tweaks ---
 


### PR DESCRIPTION
🎯 **What:**
Updated `.macos` script to handle quitting "System Settings" (macOS Ventura and later) in addition to "System Preferences" (pre-Ventura).

💡 **Why:**
This improves compatibility across different macOS versions and ensures the default scripts can cleanly apply settings without being blocked by open preference panes. Additionally, the AppleScript commands were updated to check if the application is running before sending the quit command, avoiding unintended application launches.

✅ **Verification:**
Verified that the file has correct bash syntax with `bash -n .macos`. The code review confirmed that the changes to the AppleScript format are robust and prevent negative side effects.

✨ **Result:**
The macOS settings script now reliably handles both the older "System Preferences" and the newer "System Settings" applications.

---
*PR created automatically by Jules for task [1886370862190465794](https://jules.google.com/task/1886370862190465794) started by @russellkim98*