### PR TITLE
🧹 Code Health: Remove unused `fail` helper function

### DIFF
--- a/symlink.sh
+++ b/symlink.sh
@@ -8,7 +8,6 @@ set -euo pipefail
 info() { printf "\033[1;34m%s\033[0m\n" "$1"; }
 success() { printf "\033[1;32m%s\033[0m\n" "$1"; }
 warning() { printf "\033[1;33m%s\033[0m\n" "$1"; }
-fail() { printf "\033[1;31m%s\033[0m\n" "$1"; exit 1; }
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 DRY_RUN=false


### PR DESCRIPTION
🎯 **What:** The unused `fail` helper function in `symlink.sh` was removed.
💡 **Why:** To improve code hygiene and maintainability by removing dead code.
✅ **Verification:** Verified by grepping for `fail` across the codebase, confirming no other usages existed. Ran `zsh -n symlink.sh` and `./symlink.sh --dry-run` to ensure syntax is correct and the script continues to function successfully.
✨ **Result:** A cleaner script with no dead code.

---
*PR created automatically by Jules for task [15338633195476050903](https://jules.google.com/task/15338633195476050903) started by @russellkim98*