### PR TITLE
🔒 Fix Python code injection via path interpolation in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -76,12 +76,12 @@ if [ -d "/Applications/iTerm.app" ]; then
 
     # Wrap the profile JSON in Dynamic Profiles format
     python3 -c "
-import json
-with open('$SCRIPT_DIR/iterm2-theme.json') as f:
+import sys, json
+with open(sys.argv[1]) as f:
     profile = json.load(f)
 profile['Dynamic Profile Parent Name'] = 'Default'
 print(json.dumps({'Profiles': [profile]}, indent=2))
-" > "$ITERM_PROFILES_DIR/dotfiles-profile.json"
+" "$SCRIPT_DIR/iterm2-theme.json" > "$ITERM_PROFILES_DIR/dotfiles-profile.json"
 
     # Set as default profile
     defaults write com.googlecode.iterm2 "Default Bookmark Guid" "E7BCCD8D-730C-425D-A5DE-611342D95F3D"


### PR DESCRIPTION
🎯 **What:** Fixed a Python code injection vulnerability in `setup.sh` where a shell variable (`$SCRIPT_DIR`) was directly interpolated into a multi-line Python script.
⚠️ **Risk:** If `$SCRIPT_DIR` contains malicious payloads or single quotes, it could allow arbitrary Python code execution when generating the iTerm2 dynamic profile.
🛡️ **Solution:** The inline Python string now imports `sys` and utilizes `sys.argv[1]` to accept the path securely as a command-line argument, eliminating the injection risk.

---
*PR created automatically by Jules for task [2689782512915708262](https://jules.google.com/task/2689782512915708262) started by @russellkim98*